### PR TITLE
Kartikeygour

### DIFF
--- a/urban-property-backend/pom.xml
+++ b/urban-property-backend/pom.xml
@@ -113,6 +113,12 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
+		<!--caludinary for image cloud-->
+		<dependency>
+			<groupId>com.cloudinary</groupId>
+			<artifactId>cloudinary-http44</artifactId>
+			<version>1.38.0</version> 
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/urban-property-backend/src/main/java/com/urbanproperty/Application.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/Application.java
@@ -1,13 +1,7 @@
 package com.urbanproperty;
 
-import org.modelmapper.Conditions;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 public class Application {
@@ -16,34 +10,4 @@ public class Application {
 		SpringApplication.run(Application.class, args);
 	}
 
-	/*
-	 * Configure ModelMapper as spring bean - so thar SC will manage it's life cycle
-	 * + provide it as the depcy
-	 */
-	@Bean // method level annotation - to tell SC , following method
-	// rets an object - which has to be managed as a spring bean
-	// manages - life cycle +
-	public ModelMapper modelMapper() {
-		System.out.println("in model mapper creation");
-		ModelMapper mapper = new ModelMapper();
-		mapper.getConfiguration()
-				/*
-				 * To tell ModelMapper to map only those props whose names match in src n dest.
-				 * objects
-				 */
-				.setMatchingStrategy(MatchingStrategies.STRICT)
-				/*
-				 * To tell ModelMapper not to transfer nulls from src -> dest
-				 */
-				.setPropertyCondition(Conditions.isNotNull());// use case - PUT
-		return mapper;
-
-	}
-	
-	//configure PasswordEncoder as spring bean
-			@Bean
-			PasswordEncoder passwordEncoder()
-			{
-				return new BCryptPasswordEncoder();
-			}
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/config/AppBeansConfig.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/config/AppBeansConfig.java
@@ -1,0 +1,72 @@
+package com.urbanproperty.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.modelmapper.Conditions;
+import org.modelmapper.Converter;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.cloudinary.Cloudinary;
+import com.urbanproperty.dto.PropertyResponseDto;
+import com.urbanproperty.entities.Property;
+import com.urbanproperty.entities.PropertyImage;
+@Configuration
+public class AppBeansConfig {
+	@Value("${cloudinary.cloud_name}")
+    private String cloudName;
+
+    @Value("${cloudinary.api_key}")
+    private String apiKey;
+
+    @Value("${cloudinary.api_secret}")
+    private String apiSecret;
+
+	@Bean
+    public Cloudinary cloudinary() {
+        Map<String, String> config = new HashMap<>();
+        config.put("cloud_name", cloudName);
+        config.put("api_key", apiKey);
+        config.put("api_secret", apiSecret);
+        config.put("secure", "true");
+        return new Cloudinary(config);
+    }
+    @Bean
+    public ModelMapper modelMapper() {
+        // 1. Create the ModelMapper instance and apply your general settings first.
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration()
+                .setMatchingStrategy(MatchingStrategies.STRICT) // Your excellent strict matching
+                .setPropertyCondition(Conditions.isNotNull());    // Your excellent setting to skip nulls
+
+        // 2. Now, add the specific mapping logic for Property -> PropertyResponseDto.
+        TypeMap<Property, PropertyResponseDto> typeMap = modelMapper.createTypeMap(Property.class, PropertyResponseDto.class);
+        
+        // This converter handles the Set<PropertyImage> -> Set<String> conversion
+        Converter<Set<PropertyImage>, Set<String>> imagesConverter = ctx ->
+            ctx.getSource() == null ? null : ctx.getSource().stream()
+                                                .map(PropertyImage::getImageUrl)
+                                                .collect(Collectors.toSet());
+
+        // Apply the custom converter to the 'images' field mapping
+        typeMap.addMappings(mapper -> mapper.using(imagesConverter).map(Property::getImages, PropertyResponseDto::setImages));
+
+        // 3. Return the fully configured bean.
+        return modelMapper;
+    }
+  //configure PasswordEncoder as spring bean
+	@Bean
+	PasswordEncoder passwordEncoder()
+	{
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/urban-property-backend/src/main/java/com/urbanproperty/controller/PropertyController.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/controller/PropertyController.java
@@ -1,5 +1,6 @@
 package com.urbanproperty.controller;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -11,14 +12,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.urbanproperty.dto.PropertyRequestDto;
 import com.urbanproperty.dto.PropertyResponseDto;
 import com.urbanproperty.service.PropertyService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 
 @RestController
@@ -27,12 +30,19 @@ import lombok.AllArgsConstructor;
 public class PropertyController {
 
     private final PropertyService propertyService;
+    private final ObjectMapper objectMapper; // Injecting ObjectMapper
 
-    @Operation(summary = "Create a new Property Listing (Seller Only)")
+    @Operation(summary = "Create a new Property Listing with an Image (Seller Only)")
     @PostMapping
     @PreAuthorize("hasRole('SELLER')")
-    public ResponseEntity<PropertyResponseDto> createProperty(@Valid @RequestBody PropertyRequestDto request) {
-        PropertyResponseDto createdProperty = propertyService.createProperty(request);
+    public ResponseEntity<PropertyResponseDto> createProperty(
+            @RequestParam("propertyData") String propertyDataString,
+            @RequestParam("image") MultipartFile imageFile
+    ) throws IOException {
+    	// deserializing the JSON string back into DTO
+        PropertyRequestDto requestDto = objectMapper.readValue(propertyDataString, PropertyRequestDto.class);
+        
+        PropertyResponseDto createdProperty = propertyService.createPropertyWithImage(requestDto, imageFile);
         return new ResponseEntity<>(createdProperty, HttpStatus.CREATED);
     }
 

--- a/urban-property-backend/src/main/java/com/urbanproperty/controller/PropertyController.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/controller/PropertyController.java
@@ -2,7 +2,6 @@ package com.urbanproperty.controller;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +9,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -59,6 +57,7 @@ public class PropertyController {
         PropertyResponseDto property = propertyService.getPropertyById(id);
         return ResponseEntity.ok(property);
     }
+    
     @Operation(summary = "Get All Properties for a Specific Seller (Seller or Admin Only)")
     @GetMapping("/seller/{sellerId}")
     @PreAuthorize("@customSecurity.isOwnerOrAdmin(authentication, #sellerId)")
@@ -68,14 +67,16 @@ public class PropertyController {
     }
 
     @Operation(summary = "Add an Image to a Property")
-    @PostMapping("/{id}/images")
+    @PostMapping("/{propertyId}/images")
     @PreAuthorize("hasRole('SELLER')")
-    public ResponseEntity<PropertyResponseDto> addImageToProperty(@PathVariable Long id, @RequestBody Map<String, String> payload) {
-        String imageUrl = payload.get("imageUrl");
-        if (imageUrl == null || imageUrl.isBlank()) {
-            return ResponseEntity.badRequest().build();
-        }
-        PropertyResponseDto updatedProperty = propertyService.addImageToProperty(id, imageUrl);
+    public ResponseEntity<PropertyResponseDto> uploadImageForProperty(
+            @PathVariable Long propertyId,
+            @RequestParam("image") MultipartFile file) throws IOException {
+    	 if (file.isEmpty()) {
+             return ResponseEntity.badRequest().build();
+         }
+
+         PropertyResponseDto updatedProperty = propertyService.addImageToProperty(propertyId, file);
         return ResponseEntity.ok(updatedProperty);
     }
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/dto/AmenityDto.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/dto/AmenityDto.java
@@ -21,5 +21,5 @@ public class AmenityDto {
 	  @NotBlank(message = "Name cannot be blank")
 	  private String name;
 	  
-	  private  String iconUrl;
+//	  private  String iconUrl;
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/ImageUploadService.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/ImageUploadService.java
@@ -1,0 +1,10 @@
+package com.urbanproperty.service;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploadService {
+    Map uploadImage(MultipartFile file, String publicId) throws IOException;
+}

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/ImageUploadServiceImpl.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/ImageUploadServiceImpl.java
@@ -1,0 +1,28 @@
+package com.urbanproperty.service;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.cloudinary.Cloudinary;
+
+import lombok.AllArgsConstructor;
+
+@Service
+@AllArgsConstructor
+public class ImageUploadServiceImpl implements ImageUploadService {
+
+    private final Cloudinary cloudinary;
+
+    @Override
+    public Map uploadImage(MultipartFile file, String publicId) throws IOException {
+        Map<String, Object> options = new HashMap<>();
+        options.put("public_id", publicId);
+        options.put("overwrite", false); // Prevent overwriting existing images
+
+        return this.cloudinary.uploader().upload(file.getBytes(), options);
+    }
+}

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
@@ -12,7 +12,7 @@ public interface PropertyService {
     PropertyResponseDto createProperty(PropertyRequestDto request);
     PropertyResponseDto getPropertyById(Long id);
     List<PropertyResponseDto> getAllActiveProperties();
-    PropertyResponseDto addImageToProperty(Long propertyId, String imageUrl);
+    PropertyResponseDto addImageToProperty(Long propertyId, MultipartFile imageFile) throws IOException;
     
     List<PropertyResponseDto> getAllPropertiesBySeller(Long sellerId);
     

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
@@ -1,8 +1,12 @@
 package com.urbanproperty.service;
 
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import com.urbanproperty.dto.PropertyRequestDto;
 import com.urbanproperty.dto.PropertyResponseDto;
-import java.util.List;
 
 public interface PropertyService {
     PropertyResponseDto createProperty(PropertyRequestDto request);
@@ -11,4 +15,7 @@ public interface PropertyService {
     PropertyResponseDto addImageToProperty(Long propertyId, String imageUrl);
     
     List<PropertyResponseDto> getAllPropertiesBySeller(Long sellerId);
+    
+    PropertyResponseDto createPropertyWithImage(PropertyRequestDto request, MultipartFile imageFile) throws IOException;
+
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyServiceImpl.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyServiceImpl.java
@@ -1,13 +1,16 @@
 package com.urbanproperty.service;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.urbanproperty.custom_exceptions.ResourceNotFoundException;
 import com.urbanproperty.dao.AmenityDao;
@@ -37,7 +40,51 @@ public class PropertyServiceImpl implements PropertyService {
     private final PropertyTypeDao propertyTypeDao;
     private final AmenityDao amenityDao;
     private final ModelMapper mapper;
+    private ImageUploadService imageUploadService;
 
+    @Override
+    public PropertyResponseDto createPropertyWithImage(PropertyRequestDto request, MultipartFile imageFile) throws IOException {
+        
+    	UserEntity seller = userDao.findById(request.getSellerId())
+                .orElseThrow(() -> new ResourceNotFoundException("Seller not found with id: " + request.getSellerId()));
+
+        PropertyType propertyType = propertyTypeDao.findById(request.getPropertyTypeId())
+                .orElseThrow(() -> new ResourceNotFoundException("PropertyType not found with id: " + request.getPropertyTypeId()));
+
+        Set<Amenity> amenities = new HashSet<>(amenityDao.findAllById(request.getAmenityIds()));
+
+        Property property = mapper.map(request, Property.class);
+        property.setSeller(seller);
+        property.setPropertyType(propertyType);
+        property.setAmenities(amenities);
+        property.setStatus(PropertyStatus.PENDING); 
+        
+        if (request.getDetails() != null) {
+            PropertyDetails details = mapper.map(request.getDetails(), PropertyDetails.class);
+            property.setDetails(details);
+        }
+        
+        // Save the property FIRST to generate its ID
+        Property savedProperty = propertyDao.save(property);
+        Long propertyId = savedProperty.getId();
+        
+        String originalFilename = imageFile.getOriginalFilename();
+        String sanitizedFilename = originalFilename.substring(0, originalFilename.lastIndexOf("."));
+        String publicId = "properties/" + propertyId + "/" + sanitizedFilename;
+        
+        Map uploadResult = imageUploadService.uploadImage(imageFile, publicId);
+
+        PropertyImage newImage = new PropertyImage();
+        newImage.setImageUrl((String) uploadResult.get("secure_url"));
+        newImage.setPrimary(true);
+        
+        // Link the image to the property and save again to establish the relationship
+        savedProperty.addImage(newImage);
+        Property finalProperty = propertyDao.save(savedProperty);
+
+        return mapToResponseDto(finalProperty);
+    }
+    
     @Override
     public PropertyResponseDto createProperty(PropertyRequestDto request) {
         UserEntity seller = userDao.findById(request.getSellerId())

--- a/urban-property-backend/src/main/resources/application.properties
+++ b/urban-property-backend/src/main/resources/application.properties
@@ -20,4 +20,16 @@ SECRET_KEY=x1oaEnBPgRThp3/0jOJIRZzftfu1LUrJ2wLM30C0TaoHTtLUgubktDZMsW8cDN9p
 #expiration timeout in ms
 EXP_TIMEOUT=30000000
 
+# Cloudinary Configuration
+# These values are Cloudinary account holder's
+cloudinary.cloud_name=dyjf8ocof
+cloudinary.api_key=444537745892793
+cloudinary.api_secret=_pyYwaMyzR-3ZNu0apL5EreJztQ
 
+# --- File Upload Configuration ---
+
+# Set the maximum size for a single file to 10MB
+spring.servlet.multipart.max-file-size=10MB
+
+# Set the maximum size for an entire request to 10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
The main `POST /api/v1/properties` endpoint has been updated to accept `multipart/form-data`, allowing a new property to be created along with its primary image in a single API call. The `PropertyImage` entity was added to store the image URLs.

The separate `POST /api/v1/properties/{id}/images` endpoint is also included for adding more photos to an existing property gallery. Images are automatically organized in Cloudinary under a `properties/{propertyId}` folder structure.