### PR TITLE
Secure property creation by using auth token for seller ID, and updated

### DIFF
--- a/urban-property-backend/src/main/java/com/urbanproperty/controller/PropertyController.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/controller/PropertyController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,12 +36,13 @@ public class PropertyController {
     @PreAuthorize("hasRole('SELLER')")
     public ResponseEntity<PropertyResponseDto> createProperty(
             @RequestParam("propertyData") String propertyDataString,
-            @RequestParam("image") MultipartFile imageFile
+            @RequestParam("image") MultipartFile imageFile,
+            Authentication authentication
     ) throws IOException {
     	// deserializing the JSON string back into DTO
         PropertyRequestDto requestDto = objectMapper.readValue(propertyDataString, PropertyRequestDto.class);
         
-        PropertyResponseDto createdProperty = propertyService.createPropertyWithImage(requestDto, imageFile);
+        PropertyResponseDto createdProperty = propertyService.createPropertyWithImage(requestDto, imageFile, authentication);
         return new ResponseEntity<>(createdProperty, HttpStatus.CREATED);
     }
 

--- a/urban-property-backend/src/main/java/com/urbanproperty/controller/UserController.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/controller/UserController.java
@@ -94,7 +94,7 @@ public class UserController {
 	    return ResponseEntity.ok(favorites);
 	}
 
-	@GetMapping("/admin/dashboard")
+	@GetMapping("/admin/seller-buyer-count")
 	@PreAuthorize("hasRole('ADMIN')")
 	@Operation(
 	    summary = "Get Admin Dashboard Statistics (Admin Only)",

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
@@ -3,19 +3,19 @@ package com.urbanproperty.service;
 import java.io.IOException;
 import java.util.List;
 
+import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.urbanproperty.dto.PropertyRequestDto;
 import com.urbanproperty.dto.PropertyResponseDto;
 
 public interface PropertyService {
-    PropertyResponseDto createProperty(PropertyRequestDto request);
     PropertyResponseDto getPropertyById(Long id);
     List<PropertyResponseDto> getAllActiveProperties();
     PropertyResponseDto addImageToProperty(Long propertyId, MultipartFile imageFile) throws IOException;
     
     List<PropertyResponseDto> getAllPropertiesBySeller(Long sellerId);
     
-    PropertyResponseDto createPropertyWithImage(PropertyRequestDto request, MultipartFile imageFile) throws IOException;
+    PropertyResponseDto createPropertyWithImage(PropertyRequestDto request, MultipartFile imageFile, Authentication authentication) throws IOException;
 
 }


### PR DESCRIPTION
- Removes the `sellerId` field from the `PropertyRequestDto` to prevent clients from specifying the owner of a new property.

- Modifies the `createPropertyWithImage` controller method to accept the `Authentication` principal, which is automatically provided by Spring Security.

- Updates the service layer to use the authenticated principal's name to fetch the `UserEntity` from the database, ensuring that the logged-in user is always set as the property's seller.

This change closes a security vulnerability where a malicious user could potentially create a property on behalf of another user.