### PR TITLE
Kartikeygour

### DIFF
--- a/urban-property-backend/src/main/java/com/urbanproperty/controller/AdminController.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/controller/AdminController.java
@@ -1,0 +1,43 @@
+package com.urbanproperty.controller;
+
+import com.urbanproperty.dto.admin.AdminDashboardStatsDTO;
+import com.urbanproperty.entities.PropertyStatus;
+import com.urbanproperty.service.PropertyService;
+import com.urbanproperty.service.UserService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@AllArgsConstructor
+@PreAuthorize("hasRole('ADMIN')") // Secures all endpoints in this controller
+public class AdminController {
+
+    private final PropertyService propertyService;
+    private UserService userService;
+
+    @Operation(summary = "Get counts of properties grouped by status (Admin Only)")
+    @GetMapping("/dashboard/property-status-counts")
+    public ResponseEntity<Map<PropertyStatus, Long>> getPropertyStatusCounts() {
+        Map<PropertyStatus, Long> statusCounts = propertyService.getPropertyStatusCounts();
+        return ResponseEntity.ok(statusCounts);
+    }
+    
+    @GetMapping("/dashboard/seller-buyer-count")
+	@Operation(
+	    summary = "Get Admin Dashboard Statistics (Admin Only)",
+	    description = "Provides statistics for the current year, including total user count and a monthly breakdown of new buyers and sellers."
+	)
+	public ResponseEntity<AdminDashboardStatsDTO> getAdminDashboardStats() {
+	    AdminDashboardStatsDTO stats = userService.getDashboardStatistics();
+	    return ResponseEntity.ok(stats);
+	}
+}

--- a/urban-property-backend/src/main/java/com/urbanproperty/controller/UserController.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/controller/UserController.java
@@ -93,15 +93,4 @@ public class UserController {
 	    List<PropertyResponseDto> favorites = userService.getFavoriteProperties(userId);
 	    return ResponseEntity.ok(favorites);
 	}
-
-	@GetMapping("/admin/seller-buyer-count")
-	@PreAuthorize("hasRole('ADMIN')")
-	@Operation(
-	    summary = "Get Admin Dashboard Statistics (Admin Only)",
-	    description = "Provides statistics for the current year, including total user count and a monthly breakdown of new buyers and sellers."
-	)
-	public ResponseEntity<AdminDashboardStatsDTO> getAdminDashboardStats() {
-	    AdminDashboardStatsDTO stats = userService.getDashboardStatistics();
-	    return ResponseEntity.ok(stats);
-	}
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/dao/PropertyDao.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/dao/PropertyDao.java
@@ -1,15 +1,20 @@
 package com.urbanproperty.dao;
 
-import com.urbanproperty.entities.Property;
-import com.urbanproperty.entities.PropertyStatus;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import com.urbanproperty.dto.PropertyStatusCountDto;
+import com.urbanproperty.entities.Property;
+import com.urbanproperty.entities.PropertyStatus;
 
 @Repository
 public interface PropertyDao extends JpaRepository<Property, Long> {
     List<Property> findByStatus(PropertyStatus status);
     
     List<Property> findBySellerId(Long sellerId);
+    @Query("SELECT new com.urbanproperty.dto.PropertyStatusCountDto(p.status, COUNT(p)) FROM Property p GROUP BY p.status")
+    List<PropertyStatusCountDto> countPropertiesByStatus();
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/dto/PropertyStatusCountDto.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/dto/PropertyStatusCountDto.java
@@ -1,0 +1,12 @@
+package com.urbanproperty.dto;
+
+import com.urbanproperty.entities.PropertyStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor // This constructor will be used by JPA
+public class PropertyStatusCountDto {
+    private PropertyStatus status;
+    private long count;
+}

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyService.java
@@ -2,6 +2,7 @@ package com.urbanproperty.service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.urbanproperty.dto.PropertyRequestDto;
 import com.urbanproperty.dto.PropertyResponseDto;
 import com.urbanproperty.dto.PropertyUpdateDto;
+import com.urbanproperty.entities.PropertyStatus;
 
 public interface PropertyService {
     PropertyResponseDto getPropertyById(Long id);
@@ -19,5 +21,6 @@ public interface PropertyService {
     
     PropertyResponseDto createPropertyWithImage(PropertyRequestDto request, MultipartFile imageFile, Authentication authentication) throws IOException;
     PropertyResponseDto updateProperty(Long propertyId, PropertyUpdateDto updateDto, MultipartFile imageFile, Authentication authentication) throws IOException;
-
+    
+    Map<PropertyStatus, Long> getPropertyStatusCounts();
 }

--- a/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyServiceImpl.java
+++ b/urban-property-backend/src/main/java/com/urbanproperty/service/PropertyServiceImpl.java
@@ -22,6 +22,7 @@ import com.urbanproperty.dao.UserDao;
 import com.urbanproperty.dto.PropertyDetailsDto;
 import com.urbanproperty.dto.PropertyRequestDto;
 import com.urbanproperty.dto.PropertyResponseDto;
+import com.urbanproperty.dto.PropertyStatusCountDto;
 import com.urbanproperty.dto.PropertyUpdateDto;
 import com.urbanproperty.entities.Amenity;
 import com.urbanproperty.entities.Property;
@@ -217,5 +218,18 @@ public class PropertyServiceImpl implements PropertyService {
             dto.setDetails(mapper.map(property.getDetails(), PropertyDetailsDto.class));
         }
         return dto;
+    }
+    
+    //for admin dashboard page, getting the status count
+    @Override
+    public Map<PropertyStatus, Long> getPropertyStatusCounts() {
+        List<PropertyStatusCountDto> counts = propertyDao.countPropertiesByStatus();
+
+        // 2. Converting the list into Map using Java Streams
+        return counts.stream()
+                .collect(Collectors.toMap(
+                    PropertyStatusCountDto::getStatus,
+                    PropertyStatusCountDto::getCount
+                ));
     }
 }


### PR DESCRIPTION
This PR introduces a new endpoint to provide statistics for the admin dashboard.

It adds `GET /api/v1/admin/dashboard/property-status-counts`, which returns a map of property statuses and their respective counts. The data is fetched using an efficient, custom JPA query.

A new `AdminController` has been created to house this and future admin routes, with security configured for ADMIN role access only.